### PR TITLE
Add guidelines for building the book locally. Ref #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+## Development
+
+This website was created with [JupyterBook](https://jupyterbook.org/). To set up a local development environment, follow the steps below:
+
+1. Navigate to the project directory (e.g. `mimic_wfdb_tutorials`)
+2. Install the required packages with `pip install -r requirements.txt` (preferably in a virtual environment using something like venv, virtualenv, conda etc.)
+3. Run `jupyter-book build --all ./` from within the project directory to build the book.
+4. The HTML bookfiles should have been created in a `_build` folder.


### PR DESCRIPTION
This is a minor pull request to add instructions for building the book files locally. Note that I'm currently getting a bunch of errors that prevent me from building the book, so I'll take a look at fixing these next.

I think the issue is that `requirements.txt` doesn't pin the specific versions, and there have been some breaking changes in the newer versions of the packages.

e.g. the first build error that I see is:

```
Traceback (most recent call last):
  File "/projects/mimic_wfdb_tutorials/env/bin/jupyter-book", line 8, in <module>
    sys.exit(main())
  File "/projects/mimic_wfdb_tutorials/env/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/projects/mimic_wfdb_tutorials/env/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/projects/mimic_wfdb_tutorials/env/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/projects/mimic_wfdb_tutorials/env/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/projects/mimic_wfdb_tutorials/env/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/projects/mimic_wfdb_tutorials/env/lib/python3.9/site-packages/jupyter_book/cli/main.py", line 246, in build
    _error(
  File "/projects/mimic_wfdb_tutorials/env/lib/python3.9/site-packages/jupyter_book/utils.py", line 48, in _error
    raise kind(box)
RuntimeError: 
===============================================================================

The Table of Contents file is malformed: toc is not a mapping: <class 'list'>
You may need to migrate from the old format, using:

	jupyter-book toc migrate /projects/mimic_wfdb_tutorials/_toc.yml -o /projects/mimic_wfdb_tutorials/_toc.yml

===============================================================================
```

Running the suggestion migration fixes this issue, but there are more that follow.