### PR TITLE
Pin versions in requirements file. ref #6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jupyter-book
-matplotlib
-numpy
+jupyter-book==0.9.1
+matplotlib==3.5.2
+numpy==1.22.3


### PR DESCRIPTION
It looks like the repository is using an older version of the jupyterbook package. There is a changelog for the package at: 
https://jupyterbook.org/en/stable/reference/_changelog.html

Trying to build the project using the current version of jupyterbook raises several errors, so I am pinning the older version in the requirements file. `jupyter-book==0.9.1` seems to work.

We should try to bump the version at a later date. According to https://legacy.jupyterbook.org/guide/05_faq.html there is a tool for upgrading projects, but this looks to have been deprecated.