### PR TITLE
Add initial github workflow to build the jupyter book

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,42 @@
+# Link repository with GitHub Actions
+# https://docs.github.com/en/actions/learn-github-actions/introduction-to-github-actions
+
+name: run-tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ["3.8", "3.9"]
+    steps:
+      # Checkout the latest code from the repo
+      # https://github.com/actions/checkout
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      # Setup which version of Python to use
+      # https://github.com/actions/setup-python
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      # Display the Python version being used
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      # Install the dependencies for the package.
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      # Build the book
+      - name: Build the book
+        run: jupyter-book build content/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Jinja2==3.0.3
 jupyter-book==0.9.1
 matplotlib==3.5.2
-numpy==1.22.3
+numpy>=1.10


### PR DESCRIPTION
This pull request helps to address https://github.com/MIT-LCP/mimic_wfdb_tutorials/issues/10. The workflow should:

1. attempt to build the book using the `content/` folder
2. raise an error if the book fails to build.

We could consider adding an additional step to the workflow (in a new pull request) to push the new content to the `gh-pages` branch. This looks something like the command below:

```
    # Push the book's HTML to github-pages
    - name: GitHub Pages action
      uses: peaceiris/actions-gh-pages@v3.6.1
      with:
        github_token: ${{ secrets.GITHUB_TOKEN }}
        publish_dir: ./_build/html
``` 